### PR TITLE
Try to use all discovered addresses instead of only the first one

### DIFF
--- a/client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
+++ b/client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
@@ -100,13 +100,18 @@ class SyncthingClient(private val configuration: Configuration) : Closeable {
                 .filterNot { connections.map { it.deviceId() }.contains(it.key) }
                 .filterNot { it.value.isEmpty() }
                 .forEach { (_, addresses) ->
-                    val bestAddress = addresses.first()
-                    try {
-                        listener(openConnection(bestAddress))
-                    } catch (e: IOException) {
-                        logger.warn("error connecting to device = $bestAddress", e)
-                    } catch (e: KeystoreHandler.CryptoException) {
-                        logger.warn("error connecting to device = $bestAddress", e)
+                    // try to use all addresses
+
+                    for (address in addresses) {
+                      try {
+                        listener(openConnection(address))
+
+                        break  // it worked, no need to try more
+                      } catch (e: IOException) {
+                        logger.warn("error connecting to device = $address", e)
+                      } catch (e: KeystoreHandler.CryptoException) {
+                        logger.warn("error connecting to device = $address", e)
+                      }
                     }
                 }
 


### PR DESCRIPTION
This "fixes" exceptions like the below when the route does not work because other connections are tried after it.

```
    javax.net.ssl.SSLHandshakeException: Connection closed by peer
        at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
        at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:357)
        at com.android.org.conscrypt.OpenSSLSocketImpl.waitForHandshake(OpenSSLSocketImpl.java:682)
        at com.android.org.conscrypt.OpenSSLSocketImpl.getInputStream(OpenSSLSocketImpl.java:644)
        at net.syncthing.java.bep.ConnectionHandler.connect(ConnectionHandler.kt:109)
        at net.syncthing.java.client.SyncthingClient.openConnection(SyncthingClient.kt:85)
        at net.syncthing.java.client.SyncthingClient.getPeerConnections(SyncthingClient.kt:105)
        at net.syncthing.java.client.SyncthingClient.updateIndexFromPeers(SyncthingClient.kt:117)
        at net.syncthing.java.client.SyncthingClient.access$updateIndexFromPeers(SyncthingClient.kt:38)
        at net.syncthing.java.client.SyncthingClient$1.invoke(SyncthingClient.kt:51)
        at net.syncthing.java.client.SyncthingClient$1.invoke(SyncthingClient.kt:38)
        at net.syncthing.java.client.SyncthingClientKt$sam$Runnable$9543d2f5.run(SyncthingClient.kt)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:428)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:278)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:273)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
        at java.lang.Thread.run(Thread.java:761)
```

It's eventually equal to https://github.com/syncthing/syncthing-lite/issues/6