### PR TITLE
Improve connection handling with multiple addresses

### DIFF
--- a/bep/src/main/kotlin/net/syncthing/java/bep/ConnectionHandler.kt
+++ b/bep/src/main/kotlin/net/syncthing/java/bep/ConnectionHandler.kt
@@ -197,7 +197,7 @@ class ConnectionHandler(private val configuration: Configuration, val address: D
                 .build())
     }
 
-    private fun closeBg() {
+    fun closeBg() {
         Thread { close() }.start()
     }
 
@@ -340,7 +340,13 @@ class ConnectionHandler(private val configuration: Configuration, val address: D
                 IOUtils.closeQuietly(inputStream)
                 inputStream = null
             }
-            IOUtils.closeQuietly(socket)
+            try {
+              IOUtils.closeQuietly(socket)
+            } catch (ex: Exception) {
+              // ignore this
+              // this can throw an exception if socket was not yet initialized/ set
+              // as Kotlin does an check about this, the closeQuietly does not catch it
+            }
             logger.info("closed connection {}", address)
             synchronized(clusterConfigWaitingLock) {
                 clusterConfigWaitingLock.notifyAll()


### PR DESCRIPTION
The problem was that connections which failed to connect were added to the active connections.
This caused issues with https://github.com/syncthing/syncthing-java/pull/14 as often one of the failed connections was used.

Now, connecting over the internet/ relays works "reliable" if the Syncthing Server thinks
that Syncthing Lite is not connected (shows "not connected" in the Web UI). To get
this situation, one has to restart the server. The problem is that when closing Syncthing Lite,
the Server still thinks that it is connected (and due to that new connection attempts fail).