### PR TITLE
Skip duplicate device addresses

### DIFF
--- a/client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
+++ b/client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
@@ -138,7 +138,7 @@ class SyncthingClient(private val configuration: Configuration) : Closeable {
                       }
 
                       // try to use all addresses
-                      for (address in addresses) {
+                      for (address in addresses.distinctBy { it.address }) {
                         try {
                           val newConnection = openConnection(address)
 


### PR DESCRIPTION
Device addresses were tried multiple times (I guess due to the multiple discovery servers).

With this, the time from starting syncthing lite to being connected with my computer over the internet was reduced from 22 seconds to 10 seconds (tested 2 times and restarted both sides in between). 